### PR TITLE
Use dotenv to run examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ mkmf.log
 vendor
 .ruby-version
 .bundle/
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem 'activerecord-jdbc-adapter'
 gem 'dbd-jdbc'
 gem 'dbi'
+gem "dotenv"

--- a/example/activerecord.rb
+++ b/example/activerecord.rb
@@ -1,20 +1,34 @@
 require 'activerecord-jdbc-adapter'
 require 'jdbc-vertica'
+require 'dotenv'
 
 class JdbcTest < ActiveRecord::Base
 end
 
-$username = 'dbadmin'
-$password = '********'
-$host = 'veritica.jp'
+# Create .env file containing
+# HOSTNAME=
+# PORT=
+# DATABASE=
+# USERNAME=
+# PASSWORD=
+Dotenv.load
+
+config = {
+  hostname: ENV['HOSTNAME'],
+  port:     ENV['PORT'] || "5433",
+  username: ENV['USERNAME'],
+  password: ENV['PASSWORD'],
+  database: ENV['DATABASE'] || "vmain",
+}
+puts config
 
 Jdbc::Vertica.load_driver
 ActiveRecord::Base.establish_connection adapter: 'jdbc',
   driver: 'com.vertica.jdbc.Driver',
-  url: "jdbc:vertica://#{$host}:5433/",
-  username:  $username,
-  password: $password,
-  database: 'vmain',
+  url: "jdbc:vertica://#{config[:hostname]}:#{config[:port]}/",
+  username: config[:username],
+  password: config[:password],
+  database: config[:database],
   schema_search_path: 'sandbox'
 ActiveRecord::Base.connection.execute "SET search_path TO sandbox;"
 

--- a/example/connect_and_show_tables.rb
+++ b/example/connect_and_show_tables.rb
@@ -1,16 +1,28 @@
 require 'dbi'
 require 'dbd/Jdbc'
 require 'jdbc-vertica'
+require 'dotenv'
 
-$user = 'dbadmin'
-$password = '********'
-$host = 'vertica.jp'
+# Create .env file containing
+# HOSTNAME=
+# PORT=
+# USERNAME=
+# PASSWORD=
+Dotenv.load
+
+config = {
+  hostname: ENV['HOSTNAME'],
+  port:     ENV['PORT'] || "5433",
+  username: ENV['USERNAME'],
+  password: ENV['PASSWORD'],
+}
+puts config
 
 Jdbc::Vertica.load_driver
 DBI.connect(
-  "DBI:Jdbc:vertica://#{$host}:5433/",
-  $user,
-  $password,
+  "DBI:Jdbc:vertica://#{config[:hostname]}:#{config[:port]}/",
+  config[:username],
+  config[:password],
   'driver' => 'com.vertica.jdbc.Driver'
 ) do |dbh|
   puts "Connected"

--- a/spec/jdbc/vertica_spec.rb
+++ b/spec/jdbc/vertica_spec.rb
@@ -5,7 +5,7 @@ describe Jdbc::Vertica do
     expect(Jdbc::Vertica::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  it do
+    expect { Jdbc::Vertica.load_driver }.not_to raise_error
   end
 end


### PR DESCRIPTION
Use dotenv to run examples. Create .env file like

```
HOSTNAME=xxx.xxx.xxx.xxx
PORT=5433
DATABASE=xxxx
USERNAME=xxxx
PASSWORD=xxxx
```

Since `.env` is gitignored, we can assure that the password will be not committed. 
